### PR TITLE
fixed deleteDocument so that it no longer returns null

### DIFF
--- a/backend/graphql/resolvers/Document.js
+++ b/backend/graphql/resolvers/Document.js
@@ -49,18 +49,18 @@ const documentResolver = {
 				}
 			});
 		},
-		deleteDocument: (_, { input: { id } }) => {
+		deleteDocument: (_, { input: { id } }) =>
 			Document.findById(id).then(async document => {
+				console.log(document);
 				if (document) {
-					const doc = await Document.findOneAndDelete({ _id: id });
+					await Document.findByIdAndDelete({ _id: id });
 					await DocComment.deleteMany({ document: document._id });
-					// console.log(doc);
-					return doc;
+					console.log(document);
+					return document;
 				} else {
 					throw new ValidationError("Document doesn't exist");
 				}
-			});
-		},
+			}),
 		subscribeDoc: (_, { input: { id } }, { user: { _id } }) =>
 			Document.findOneAndUpdate(
 				{ _id: id },


### PR DESCRIPTION
# Description

Previously, when deleting a document, the mutation for deleting a document would return `null` instead of the id of the deleted item. By changing the functions used and doing some cleaning up, it now returns the id of the deleted document.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code has been reviewed by at least one peer
- [x] There are no merge conflicts
