### PR TITLE
Overall Style changes to components in Documents Tab

### DIFF
--- a/frontend/src/Content/DocumentsTab/Doc.js
+++ b/frontend/src/Content/DocumentsTab/Doc.js
@@ -1,12 +1,24 @@
 import React from 'react';
 import styled from 'styled-components';
 import { DragSource } from 'react-dnd';
+import { KeyboardArrowRight } from 'styled-icons/material/KeyboardArrowRight';
 
-const IndividualDocument = styled.p`
+const IndividualDocument = styled.div`
 	color: white;
 	margin: 10px;
 	padding: 10px;
+	height: ${props => (props.noFolder ? 'auto' : '50px')};
+	width: ${props => (props.noFolder ? 'auto' : '130px')};
 	border: 2px solid white;
+	border-radius: 5px;
+	display: ${props => (props.noFolder ? 'block' : 'flex')};
+	align-items: ${props => (props.noFolder ? 'center' : 'start')};
+	cursor: pointer;
+`;
+
+const Arrow = styled(KeyboardArrowRight)`
+	height: 25px;
+	margin-left: 10px;
 `;
 
 const docSource = {
@@ -38,8 +50,11 @@ class Doc extends React.Component {
 
 		return connectDragSource(
 			<div>
-				<IndividualDocument style={{ opacity }}>
-					{document.title}
+				<IndividualDocument noFolder={this.props.noFolder} style={{ opacity }}>
+					{document.title.length > 11 && !this.props.noFolder
+						? `${document.title.substring(0, 11)}...`
+						: document.title}
+					{this.props.noFolder ? <Arrow /> : <></>}
 				</IndividualDocument>
 			</div>
 		);

--- a/frontend/src/Content/DocumentsTab/Documents/DocumentContainer.js
+++ b/frontend/src/Content/DocumentsTab/Documents/DocumentContainer.js
@@ -14,6 +14,24 @@ const Container = styled.div`
 	background-color: #4a4550;
 	min-width: 300px;
 	min-height: 50px;
+	position: relative;
+`;
+
+const ContainerTitle = styled.div`
+	position: absolute;
+	text-align: center;
+	height: 40px;
+	width: 180px;
+	top: -20px;
+	left: 20px;
+	background-color: #4a4550;
+	/* background-color: #5a5560; */
+
+	p {
+		color: white;
+		font-size: 25px;
+		letter-spacing: 1px;
+	}
 `;
 
 const Error = styled.p`
@@ -28,15 +46,15 @@ const FormDiv = styled.div`
 
 const SortForm = styled.form`
 	height: 50px;
+	margin-top: 15px;
 	label {
 		color: white;
-		font-size: 20px;
 	}
 	select {
 		margin-left: 10px;
 	}
 	option {
-		height: 50px;
+		height: 25px;
 	}
 `;
 
@@ -73,10 +91,13 @@ class DocumentContainer extends React.Component {
 		return connectDropTarget(
 			<div>
 				<Container style={{ background: backgroundColor }}>
+					<ContainerTitle>
+						<p>DOCUMENTS</p>
+					</ContainerTitle>
 					<FormDiv>
 						<SortForm>
 							<label>
-								Folder Sort:
+								Sort:
 								<select
 									value={this.props.sortOption}
 									onChange={this.props.sortChange}
@@ -125,6 +146,7 @@ class DocumentContainer extends React.Component {
 											>
 												<Doc
 													document={doc}
+													noFolder
 													handleDrop={(id, folderId) =>
 														this.updateDrop(id, folderId)
 													}

--- a/frontend/src/Content/DocumentsTab/Documents/DocumentDetails.js
+++ b/frontend/src/Content/DocumentsTab/Documents/DocumentDetails.js
@@ -14,13 +14,13 @@ import {
 
 // ------------- Style Imports ---------------------- //
 import styled from 'styled-components';
-import IconButton from '@material-ui/core/IconButton';
+// import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import { colors } from '../../../colorVariables';
 import CardHeader from '@material-ui/core/CardHeader';
 import Avatar from '@material-ui/core/Avatar';
 import CardContent from '@material-ui/core/CardContent';
-import SendIcon from '@material-ui/icons/Send';
+// import SendIcon from '@material-ui/icons/Send';
 
 // ------------- Icon imports ------------------------------- //
 
@@ -29,6 +29,7 @@ import { FileAlt } from 'styled-icons/fa-solid/FileAlt';
 // import { FileExcel } from 'styled-icons/fa-solid/FileExcel';
 // import { FilePlay } from 'styled-icons/icomoon/FilePlay';
 // import { FilePdf } from 'styled-icons/icomoon/FilePdf';
+import { KeyboardArrowRight } from 'styled-icons/material/KeyboardArrowRight';
 
 // ------------- Modal styling imports ---------------------- //
 import {
@@ -105,6 +106,21 @@ const DocumentIconDiv = styled.div`
 
 const DocumentIcon = styled(FileAlt)`
 	height: 100px;
+`;
+
+const ArrowDiv = styled.div`
+	height: 150px;
+	display: flex;
+	align-items: center;
+
+	&:hover {
+		background-color: #392d40;
+		transition: 0.3s all ease-in-out;
+	}
+`;
+
+const Arrow = styled(KeyboardArrowRight)`
+	height: 25px;
 `;
 
 class DocumentDetails extends React.Component {
@@ -226,6 +242,8 @@ class DocumentDetails extends React.Component {
 											? document.doc_url
 											: `http://www.${document.doc_url}`
 									}
+									target="_blank"
+									rel="noopener noreferrer"
 								>
 									<DocUrl paragraph component="p">
 										VIEW
@@ -441,9 +459,12 @@ class DocumentDetails extends React.Component {
 											onChange={this.handleChange}
 											placeholder="Leave a comment..."
 										/>
-										<IconButton type="submit">
+										{/* <IconButton type="submit">
 											<SendIcon style={{ color: colors.text }} />
-										</IconButton>
+										</IconButton> */}
+										<ArrowDiv>
+											<Arrow />
+										</ArrowDiv>
 									</StyledModalNewCommentForm>
 								</>
 							);

--- a/frontend/src/Content/DocumentsTab/Folders/Folder.js
+++ b/frontend/src/Content/DocumentsTab/Folders/Folder.js
@@ -6,7 +6,8 @@ import { compose } from 'react-apollo';
 import { updateDocument } from '../../mutations/documents';
 
 const IndividualFolder = styled.div`
-	min-height: 200px;
+	height: 200px;
+	width: 175px;
 	color: black;
 	background-color: #a9a4b0;
 	text-align: center;
@@ -24,8 +25,21 @@ const IndividualFolder = styled.div`
 		100% 100%,
 		0% 100%
 	);
-
 	cursor: pointer;
+`;
+
+const DocumentDiv = styled.div`
+	height: 90%;
+	width: 159px;
+	overflow-y: auto;
+
+	&::-webkit-scrollbar {
+		width: 10px;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		background-color: white;
+	}
 `;
 
 function collect(connect, monitor) {
@@ -76,20 +90,24 @@ class Folder extends React.Component {
 		return connectDropTarget(
 			<div>
 				<IndividualFolder style={{ background: backgroundColor }}>
-					{folder.title}
-					{this.props.findDocumentsByFolder.length ? (
-						this.props.findDocumentsByFolder.map(doc => {
-							return (
-								<Doc
-									key={doc._id}
-									document={doc}
-									handleDrop={(id, folderId) => this.updateDrop(id, folderId)}
-								/>
-							);
-						})
-					) : (
-						<></>
-					)}
+					{folder.title.length > 18
+						? `${folder.title.substring(0, 18)}...`
+						: folder.title}
+					<DocumentDiv>
+						{this.props.findDocumentsByFolder.length ? (
+							this.props.findDocumentsByFolder.map(doc => {
+								return (
+									<Doc
+										key={doc._id}
+										document={doc}
+										handleDrop={(id, folderId) => this.updateDrop(id, folderId)}
+									/>
+								);
+							})
+						) : (
+							<></>
+						)}
+					</DocumentDiv>
 				</IndividualFolder>
 			</div>
 		);

--- a/frontend/src/Content/DocumentsTab/Folders/FolderDetails.js
+++ b/frontend/src/Content/DocumentsTab/Folders/FolderDetails.js
@@ -10,7 +10,7 @@ import { updateDocument } from '../../mutations/documents';
 import DocumentDetails from '../Documents/DocumentDetails';
 
 // ------------- Style Imports ---------------------- //
-// import styled from 'styled-components';
+import styled from 'styled-components';
 import CloseIcon from '@material-ui/icons/Close';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
@@ -25,12 +25,34 @@ import {
 	StyledModalClose,
 	StyledModalPaper,
 	StyledModalTitle,
-	StyledModalBody,
 	StyledModalButton,
 	StyledModalForm,
 	StyledModalInput,
 	StyledModalIconButton
 } from '../../Modal.styles';
+
+// ---------------- Styled Components ---------------------- //
+
+const ModalTitle = styled(StyledModalTitle)`
+	h2 {
+		font-size: 30px;
+		text-align: center;
+		margin-left: 30px;
+	}
+`;
+
+const SmallerTitle = styled(ModalTitle)`
+	h2 {
+		font-size: 18px;
+	}
+`;
+
+const DocumentTitle = styled(StyledModalTitle)`
+	h2 {
+		font-size: 18px;
+		margin-left: 15px;
+	}
+`;
 
 class FolderDetails extends React.Component {
 	constructor(props) {
@@ -141,9 +163,7 @@ class FolderDetails extends React.Component {
 										</CardContent>
 									) : (
 										<>
-											<StyledModalTitle variant="h5" component="h3">
-												{folder.title}
-											</StyledModalTitle>
+											<ModalTitle>{folder.title}</ModalTitle>
 
 											{/* Load all the images attached to the message */}
 											<CardActions
@@ -193,9 +213,9 @@ class FolderDetails extends React.Component {
 									{findDocumentsByFolder.length ? (
 										<StyledModalTitle>Documents</StyledModalTitle>
 									) : (
-										<StyledModalTitle>
+										<SmallerTitle>
 											No document at the moment, drag some in!
-										</StyledModalTitle>
+										</SmallerTitle>
 									)}
 									{findDocumentsByFolder.map(document => (
 										<StyledModalPaper key={document._id}>
@@ -215,12 +235,7 @@ class FolderDetails extends React.Component {
 												}}
 											/>
 											<CardContent>
-												<StyledModalTitle component="p">
-													{document.title}
-												</StyledModalTitle>
-												<StyledModalBody paragraph component="p">
-													{document.doc_url}
-												</StyledModalBody>
+												<DocumentTitle>{document.title}</DocumentTitle>
 											</CardContent>
 
 											{/* Check to see if the comment is the users and thus can be edited or deleted */}
@@ -246,8 +261,20 @@ class FolderDetails extends React.Component {
 														this.toggleDocumentDetail(document);
 													}}
 												>
-													View
+													Details
 												</StyledModalButton>
+												<a
+													href={
+														document.doc_url.includes('http://') ||
+														document.doc_url.includes('https://')
+															? document.doc_url
+															: `http://www.${document.doc_url}`
+													}
+													target="_blank"
+													rel="noopener noreferrer"
+												>
+													<StyledModalButton>View</StyledModalButton>
+												</a>
 											</CardContent>
 										</StyledModalPaper>
 									))}

--- a/frontend/src/Content/DocumentsTab/Folders/Folders.js
+++ b/frontend/src/Content/DocumentsTab/Folders/Folders.js
@@ -11,6 +11,25 @@ const FolderContainer = styled.div`
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: center;
+	padding: 10px;
+	padding-bottom: 20px;
+	border: 2px solid #4a4550;
+	position: relative;
+`;
+
+const ContainerTitle = styled.div`
+	position: absolute;
+	width: 150px;
+	text-align: center;
+	top: -20px;
+	left: 20px;
+	background-color: #5a5560;
+
+	p {
+		color: white;
+		font-size: 25px;
+		letter-spacing: 1px;
+	}
 `;
 
 const Error = styled.p`
@@ -18,22 +37,22 @@ const Error = styled.p`
 `;
 
 const FormDiv = styled.div`
-	width: 92%;
+	width: 95%;
 	display: flex;
 	flex-direction: row-reverse;
 `;
 
 const SortForm = styled.form`
 	height: 50px;
+	margin-top: 15px;
 	label {
 		color: white;
-		font-size: 20px;
 	}
 	select {
 		margin-left: 10px;
 	}
 	option {
-		height: 50px;
+		height: 25px;
 	}
 `;
 
@@ -62,10 +81,13 @@ class Folders extends Component {
 		// console.log('props from folder: ', this.props);
 		return (
 			<FolderContainer>
+				<ContainerTitle>
+					<p>FOLDERS</p>
+				</ContainerTitle>
 				<FormDiv>
 					<SortForm>
 						<label>
-							Folder Sort:
+							Sort:
 							<select value={this.state.sortOption} onChange={this.sortChange}>
 								<option value="newest">Newest First</option>
 								<option value="oldest">Oldest First</option>


### PR DESCRIPTION
# Description

Folders.js
- Folders now have a fixed size
- Any folders with more than two documents will have a scrollbar so that users can scroll through the documents
- Scrollbar is colored white. For the _aesthetic_ .

Documents.js
- Documents are now rounded, with an arrow to make them feel more clickable. Like a button.

DocumentDetails.js
- Replaced the `send` icon with the one that appears on the Documents

FolderDetails.js
- Changed the folder title's styling so that it looks more like the document modal one
- The document cards in the modal now display the user who made them and the title only
- Renamed `View` button to say `Details`, as it's supposed to show the document detail modal
- Added a new `View` button so that you can visit the document's URL

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change status
- [x] Complete, tested, ready to review and merge
