### PR TITLE
changed reference of toggleDocumentDetail to Detail in Documents.js

### DIFF
--- a/frontend/src/Content/DocumentsTab/Documents/Documents.js
+++ b/frontend/src/Content/DocumentsTab/Documents/Documents.js
@@ -28,7 +28,7 @@ class Documents extends Component {
 			<div>
 				<div>
 					<DocContainer
-						toggleDocumentDetail={this.toggleDocumentDetail}
+						toggleDocumentDetail={this.Detail}
 						team={this.props.team._id}
 						sortOption={this.state.sortOption}
 						sortChange={this.sortChange}
@@ -36,7 +36,7 @@ class Documents extends Component {
 				</div>
 				<DocumentDetails
 					open={this.state.documentDetailOpen}
-					hideModal={() => this.toggleDocumentDetail(null)}
+					hideModal={() => this.Detail(null)}
 					document={this.state.currentDocument}
 					currentUser={this.props.currentUser}
 					team={this.props.team._id}


### PR DESCRIPTION
# Description

The function toggleDocumentDetail was renamed to Detail, but its name was not changed wherever it was invoked. This fixes that so that Document Modals work again.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge

# Checklist:

- [x] I have performed a self-review of my own code
- [x] There are no merge conflicts
