### PR TITLE
The Folder Styling Update

### DIFF
--- a/frontend/src/Content/DocumentsTab/Doc.js
+++ b/frontend/src/Content/DocumentsTab/Doc.js
@@ -1,18 +1,23 @@
 import React from 'react';
 import styled from 'styled-components';
 import { DragSource } from 'react-dnd';
+import { FileAlt } from 'styled-icons/fa-solid/FileAlt';
 import { KeyboardArrowRight } from 'styled-icons/material/KeyboardArrowRight';
+
+// ---------------- Styled Components ---------------------- //
 
 const IndividualDocument = styled.div`
 	color: white;
-	margin: 10px;
+	margin: ${props => (props.noFolder ? '10px' : '10px auto')};
 	padding: 10px;
 	height: ${props => (props.noFolder ? 'auto' : '50px')};
-	width: ${props => (props.noFolder ? 'auto' : '130px')};
+	width: ${props => (props.noFolder ? 'auto' : '230px')};
+	/* width: ${props => (props.noFolder ? 'auto' : '130px')}; */
 	border: 2px solid white;
 	border-radius: 5px;
 	display: ${props => (props.noFolder ? 'block' : 'flex')};
-	align-items: ${props => (props.noFolder ? 'center' : 'start')};
+	align-items: center;
+	/* align-items: ${props => (props.noFolder ? 'center' : 'start')}; */
 	cursor: pointer;
 	white-space: ${props => (props.noFolder ? 'normal' : 'nowrap')};
 	overflow: ${props => (props.noFolder ? 'auto' : 'hidden')};
@@ -22,6 +27,11 @@ const IndividualDocument = styled.div`
 const Arrow = styled(KeyboardArrowRight)`
 	height: 25px;
 	margin-left: 10px;
+`;
+
+const FileIcon = styled(FileAlt)`
+	height: 12px;
+	margin-right: 10px;
 `;
 
 const docSource = {
@@ -54,8 +64,9 @@ class Doc extends React.Component {
 		return connectDragSource(
 			<div>
 				<IndividualDocument noFolder={this.props.noFolder} style={{ opacity }}>
+					<FileIcon />
 					{document.title.length > 11 && !this.props.noFolder
-						? `${document.title.substring(0, 11)}...`
+						? `${document.title.substring(0, 19)}...`
 						: document.title}
 					{this.props.noFolder ? <Arrow /> : <></>}
 				</IndividualDocument>

--- a/frontend/src/Content/DocumentsTab/Documents/DocumentContainer.js
+++ b/frontend/src/Content/DocumentsTab/Documents/DocumentContainer.js
@@ -22,14 +22,14 @@ const ContainerTitle = styled.div`
 	text-align: center;
 	height: 40px;
 	width: 180px;
-	top: -20px;
+	top: -15px;
 	left: 20px;
 	background-color: #4a4550;
 	/* background-color: #5a5560; */
 
 	p {
 		color: white;
-		font-size: 25px;
+		font-size: 18px;
 		letter-spacing: 1px;
 	}
 `;

--- a/frontend/src/Content/DocumentsTab/Documents/DocumentDetails.js
+++ b/frontend/src/Content/DocumentsTab/Documents/DocumentDetails.js
@@ -20,7 +20,6 @@ import CloseIcon from '@material-ui/icons/Close';
 import CardContent from '@material-ui/core/CardContent';
 
 // ------------- Icon imports ------------------------------- //
-import { FileAlt } from 'styled-icons/fa-solid/FileAlt';
 import { KeyboardArrowRight } from 'styled-icons/material/KeyboardArrowRight';
 
 // ------------- Modal styling imports ---------------------- //
@@ -102,15 +101,6 @@ const DocUrl = styled(StyledModalBody)`
 		background-color: #392d40;
 		transition: 0.3s all ease-in-out;
 	}
-`;
-const DocumentIconDiv = styled.div`
-	width: 100%;
-	display: flex;
-	justify-content: center;
-`;
-
-const DocumentIcon = styled(FileAlt)`
-	height: 100px;
 `;
 
 // this needs to be a button for functionality purposes
@@ -333,9 +323,6 @@ class DocumentDetails extends React.Component {
 								<CardContent>
 									{/* View document info */}
 									<ModalTitle>{document.title}</ModalTitle>
-									<DocumentIconDiv>
-										<DocumentIcon />
-									</DocumentIconDiv>
 									<a
 										href={
 											document.doc_url.includes('http://') ||

--- a/frontend/src/Content/DocumentsTab/Folders/Folder.js
+++ b/frontend/src/Content/DocumentsTab/Folders/Folder.js
@@ -8,30 +8,33 @@ import { UPDATE_DOCUMENT } from '../../../constants/mutations';
 
 const IndividualFolder = styled.div`
 	height: 200px;
-	width: 175px;
-	color: black;
+	width: 300px;
 	background-color: #a9a4b0;
 	text-align: center;
 	padding: 40px 10px 10px 10px;
 	border: 2px solid white;
 	border-radius: 5px;
 	margin: 10px;
+	cursor: pointer;
 	clip-path: polygon(
 		0% 0%,
-		45% 0%,
-		55% 10%,
+		25% 0%,
+		30% 10%,
 		100% 10%,
 		99% 10%,
 		100% 11%,
 		100% 100%,
 		0% 100%
 	);
-	cursor: pointer;
+
+	p {
+		margin: 0;
+	}
 `;
 
 const DocumentDiv = styled.div`
 	height: 90%;
-	width: 159px;
+	width: 279px;
 	overflow-y: auto;
 
 	&::-webkit-scrollbar {
@@ -119,9 +122,11 @@ class Folder extends React.Component {
 		return connectDropTarget(
 			<div>
 				<IndividualFolder style={{ background: backgroundColor }}>
-					{folder.title.length > 18
-						? `${folder.title.substring(0, 18)}...`
-						: folder.title}
+					<p>
+						{folder.title.length > 18
+							? `${folder.title.substring(0, 18)}...`
+							: folder.title}
+					</p>
 					<DocumentDiv>
 						{this.props.findDocumentsByFolder.length ? (
 							this.props.findDocumentsByFolder.map(doc => {

--- a/frontend/src/Content/DocumentsTab/Folders/Folders.js
+++ b/frontend/src/Content/DocumentsTab/Folders/Folders.js
@@ -18,14 +18,15 @@ const FolderContainer = styled.div`
 const ContainerTitle = styled.div`
 	position: absolute;
 	width: 150px;
+	height: 40px;
 	text-align: center;
-	top: -20px;
+	top: -15px;
 	left: 20px;
 	background-color: #5a5560;
 
 	p {
 		color: white;
-		font-size: 25px;
+		font-size: 18px;
 		letter-spacing: 1px;
 	}
 `;


### PR DESCRIPTION
# Description

### Doc.js
- Document divs now show a small file icon next to the title of the document
- Now has a longer cutoff before the rest of the document's title is no longer shown

### DocumentContainer.js, Folders.js
- The font size of the titles of the containers has been decreased

### DocumentDetails.js
- The large file icon that lived here was removed

### Folder.js
- Folders are now wider

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Change status
- [x] Complete, but not tested (may need new tests)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
