### PR TITLE
Turns Modals into Fullscreen Modals for Mobile; Bug Fixes

### DIFF
--- a/frontend/src/Content/DocumentsTab/Documents/DocumentContainer.js
+++ b/frontend/src/Content/DocumentsTab/Documents/DocumentContainer.js
@@ -14,6 +14,7 @@ import styled from 'styled-components';
 import { colors } from '../../../colorVariables';
 import Select from '@material-ui/core/Select';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
+import { MenuItem } from '@material-ui/core';
 
 const Container = styled.div`
 	display: flex;
@@ -60,7 +61,9 @@ const SortForm = styled.form`
 	color: white;
 `;
 
-const StyledOutline = styled(OutlinedInput)`
+const StyledOutline = styled(OutlinedInput).attrs(() => ({
+	labelWidth: 10
+}))`
 	height: 30px;
 	border-radius: 5px;
 `;
@@ -122,8 +125,8 @@ class DocumentContainer extends React.Component {
 									onChange={this.props.sortChange}
 									input={<StyledOutline name="Sort" />}
 								>
-									<option value="newest">Newest First</option>
-									<option value="oldest">Oldest First</option>
+									<MenuItem value="newest">Newest First</MenuItem>
+									<MenuItem value="oldest">Oldest First</MenuItem>
 								</StyledSelect>
 							</label>
 						</SortForm>

--- a/frontend/src/Content/DocumentsTab/Documents/DocumentDetails.js
+++ b/frontend/src/Content/DocumentsTab/Documents/DocumentDetails.js
@@ -19,6 +19,7 @@ import styled from 'styled-components';
 import CloseIcon from '@material-ui/icons/Close';
 import CardContent from '@material-ui/core/CardContent';
 import { StyledProgressSpinnerSecondary } from '../../../app-styles';
+import mediaQueryFor from '../../../_global_styles/responsive_querie';
 
 // ------------- Icon imports ------------------------------- //
 import { KeyboardArrowRight } from 'styled-icons/material/KeyboardArrowRight';
@@ -43,8 +44,8 @@ import {
 // ---------------- Styled Components ---------------------- //
 
 const ModalContents = styled.div`
-	height: 700px;
-	width: 565px;
+	height: ${mediaQueryFor.smDevice ? 'auto' : '700px'};
+	width: ${mediaQueryFor.smDevice ? 'auto' : '565px'};
 	overflow-y: auto;
 	padding-right: 1.3em;
 	margin-top: 1rem;

--- a/frontend/src/Content/DocumentsTab/Folders/FolderDetails.js
+++ b/frontend/src/Content/DocumentsTab/Folders/FolderDetails.js
@@ -36,10 +36,11 @@ import {
 import styled from 'styled-components';
 import { colors } from '../../../colorVariables';
 import { StyledProgressSpinnerSecondary } from '../../../app-styles';
+import mediaQueryFor from '../../../_global_styles/responsive_querie';
 
 const ModalContents = styled.div`
-	height: 700px;
-	width: 565px;
+	height: ${mediaQueryFor.smDevice ? 'auto' : '700px'};
+	width: ${mediaQueryFor.smDevice ? 'auto' : '565px'};
 	overflow-y: auto;
 	padding-right: 1.3em;
 	margin-top: 1rem;

--- a/frontend/src/Content/DocumentsTab/Folders/Folders.js
+++ b/frontend/src/Content/DocumentsTab/Folders/Folders.js
@@ -14,6 +14,7 @@ import OutlinedInput from '@material-ui/core/OutlinedInput';
 // ------------- Style Imports ---------------------- //
 import styled from 'styled-components';
 import { StyledProgressSpinner } from '../../../app-styles';
+import { MenuItem } from '@material-ui/core';
 
 const FolderContainer = styled.div`
 	display: flex;
@@ -58,7 +59,9 @@ const SortForm = styled.form`
 	color: white;
 `;
 
-const StyledOutline = styled(OutlinedInput)`
+const StyledOutline = styled(OutlinedInput).attrs(() => ({
+	labelWidth: 10
+}))`
 	height: 30px;
 	border-radius: 5px;
 `;
@@ -106,8 +109,8 @@ class Folders extends Component {
 								onChange={this.sortChange}
 								input={<StyledOutline name="Sort" />}
 							>
-								<option value="newest">Newest First</option>
-								<option value="oldest">Oldest First</option>
+								<MenuItem value="newest">Newest First</MenuItem>
+								<MenuItem value="oldest">Oldest First</MenuItem>
 							</StyledSelect>
 						</label>
 					</SortForm>

--- a/frontend/src/Content/MessageBoard/MessageBoard.js
+++ b/frontend/src/Content/MessageBoard/MessageBoard.js
@@ -16,6 +16,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { colors } from '../../colorVariables';
 import Select from '@material-ui/core/Select';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
+import { MenuItem } from '@material-ui/core';
 
 const styles = theme => ({
 	root: {
@@ -99,7 +100,9 @@ const SortForm = styled.form`
 	font-size: 16px;
 `;
 
-const StyledOutline = styled(OutlinedInput)`
+const StyledOutline = styled(OutlinedInput).attrs(() => ({
+	labelWidth: 10
+}))`
 	height: 30px;
 	border-radius: 5px;
 `;
@@ -164,13 +167,13 @@ class MessageBoard extends React.Component {
 							<label>
 								Sort:
 								<StyledSelect
-									outlined
+									outlined="true"
 									value={this.state.sortOption}
 									onChange={this.sortChange}
 									input={<StyledOutline name="Sort" />}
 								>
-									<option value="newest">Newest First</option>
-									<option value="oldest">Oldest First</option>
+									<MenuItem value="newest">Newest First</MenuItem>
+									<MenuItem value="oldest">Oldest First</MenuItem>
 								</StyledSelect>
 							</label>
 						</SortForm>

--- a/frontend/src/Content/MessageBoard/MessageDetail.js
+++ b/frontend/src/Content/MessageBoard/MessageDetail.js
@@ -25,7 +25,7 @@ import styled from 'styled-components';
 import { colors } from '../../colorVariables';
 import { KeyboardArrowRight } from 'styled-icons/material/KeyboardArrowRight';
 import { StyledProgressSpinnerSecondary } from '../../app-styles';
-
+import mediaQueryFor from '../../_global_styles/responsive_querie';
 // ------------- Modal styling imports ---------------------- //
 import {
 	StyledModal,
@@ -56,8 +56,8 @@ const MessageTitle = styled(StyledModalTitle)`
 `;
 
 const ModalContents = styled.div`
-	height: 700px;
-	width: 565px;
+	height: ${mediaQueryFor.smDevice ? 'auto' : '700px'};
+	width: ${mediaQueryFor.smDevice ? 'auto' : '565px'};
 	overflow-y: auto;
 	padding-right: 1.3em;
 	margin-top: 1rem;

--- a/frontend/src/Content/Modal.styles.js
+++ b/frontend/src/Content/Modal.styles.js
@@ -14,6 +14,7 @@ import CardActions from '@material-ui/core/CardActions';
 // ------------- global styles imports ---------------------- //
 import { palette, colors } from '../colorVariables';
 import { Paper } from '@material-ui/core';
+import mediaQueryFor from '../_global_styles/responsive_querie';
 // import mediaQueryFor from '../../_global_styles/responsive_querie';
 
 // All modals basically follow this structure ... basically ... :
@@ -42,6 +43,7 @@ import { Paper } from '@material-ui/core';
 export const StyledModal = styled(Dialog).attrs(() => ({
 	fullWidth: true, //<--- BTW the weird `attrs` format is how you pass new props using styled components to MUI components.
 	// ={mediaQueryFor.smDevice}
+	fullScreen: window.innerWidth <= 576 ? true : false,
 	scroll: 'body',
 	PaperProps: {
 		style: {

--- a/frontend/src/Content/TeamOptions/TeamDetails.js
+++ b/frontend/src/Content/TeamOptions/TeamDetails.js
@@ -16,6 +16,7 @@ import Logo from '../../assets/TH_favicon.png';
 // ------------- Style Imports ---------------------- //
 import styled from 'styled-components';
 import { colors } from '../../colorVariables';
+import mediaQueryFor from '../../_global_styles/responsive_querie';
 
 // ------------- MUI Imports ---------------------- //
 import CloseIcon from '@material-ui/icons/Close';
@@ -42,8 +43,8 @@ import {
 // ---------------- Styled Components ---------------------- //
 
 const ModalContents = styled.div`
-	height: 700px;
-	width: 565px;
+	height: ${mediaQueryFor.smDevice ? 'auto' : '700px'};
+	width: ${mediaQueryFor.smDevice ? 'auto' : '565px'};
 	overflow-y: auto;
 	padding-right: 1.3em;
 	margin-top: 1rem;

--- a/frontend/src/DashboardView/components/TeamList/TeamList.styles.js
+++ b/frontend/src/DashboardView/components/TeamList/TeamList.styles.js
@@ -74,7 +74,7 @@ const Button = styled(IconButton)`
 `;
 
 const TeamsList = styled.div`
-	width: 100%;
+	width: ${mediaQueryFor.smDevice ? '95%' : '100%'};
 	margin: 0 auto;
 	display: flex;
 	flex-flow: column;


### PR DESCRIPTION
# Description

### DocumentContainer.js, Folders.js, MessageBoard.js
- Fixes sort form so that error messages no longer appear in the console

### DocumentDetails.js, FolderDetails.js, MessageDetail.js, TeamDetails.js
- Added a Media Query so that the modals no longer have a fixed width and height at window widths under 576px

### Modal.styles.js
- Added a 'Media Query' that allows modals to go full screen

### TeamList.styles.js
- Added a Media Query on width in order to remove horizontal scrollbar

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, but not tested (may need new tests)

# Checklist:

- [x] There are no merge conflicts
